### PR TITLE
Request the HTTP or HTTPS version of jQuery depending on the current prot

### DIFF
--- a/layout.jade
+++ b/layout.jade
@@ -2,7 +2,7 @@ doctype 5
 html
   head
     title Shorty
-    script(src="//ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js")
+    script(src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js")
     script(src="/socket.io/socket.io.js")
     script(src="/js/animation.js")
     :stylus


### PR DESCRIPTION
Fixes the content warning: ![](http://f.cl.ly/items/42343w1G043C1w0Y4222/Screen%20Shot%202011-09-26%20at%204.03.22%20PM.png)
